### PR TITLE
Fix dashboard component to display its content

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "launch": "npm run start"
+  }
+}

--- a/dose-ninja/src/app/dashboard/dashboard.component.ts
+++ b/dose-ninja/src/app/dashboard/dashboard.component.ts
@@ -1,8 +1,12 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterOutlet } from '@angular/router';
+import { MatTabsModule } from '@angular/material/tabs';
 
 @Component({
   selector: 'app-dashboard',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, RouterOutlet, MatTabsModule],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.css'
 })


### PR DESCRIPTION
Configure `DashboardComponent` to properly display its content.

* Import `CommonModule`, `RouterOutlet`, and `MatTabsModule` in `dose-ninja/src/app/dashboard/dashboard.component.ts`.
* Add `standalone: true` property to the `@Component` decorator.
* Add `CommonModule`, `RouterOutlet`, and `MatTabsModule` to the `imports` array in the `@Component` decorator.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alwat83/prod_dose?shareId=XXXX-XXXX-XXXX-XXXX).